### PR TITLE
Module folder should be called Modules, so we don't end up with a Mod…

### DIFF
--- a/4_publish/configs/sitecore-cd.json
+++ b/4_publish/configs/sitecore-cd.json
@@ -57,14 +57,14 @@
         "CreateModuleConfiguration":{
             "Type": "EnsurePath",
             "Params": {
-                "Exists": "[joinpath(variable('Site.PhysicalPath'), '/App_Config/Module/PublishingService')]"            
+                "Exists": "[joinpath(variable('Site.PhysicalPath'), '/App_Config/Modules/PublishingService')]"            
             }
         },
         "InstallModuleConfiguration":{
             "Type": "Copy",
             "Params": {
                 "Source": "[joinpath(variable('TempFolder'), '/files/App_Config/Modules/PublishingService', 'Sitecore.Publishing.Service.Delivery.config')]",
-                "Destination": "[joinpath(variable('Site.PhysicalPath'), '/App_Config/Module/PublishingService')]"
+                "Destination": "[joinpath(variable('Site.PhysicalPath'), '/App_Config/Modules/PublishingService')]"
             }
         },
         "Cleanup":{


### PR DESCRIPTION
Module folder should be called Modules, so we don't end up with a Module folder on the CD Server, where as other modules like for example Coveo are installed in the Modules folder (keep it consistent like the CM script ;-))

But thanks for the great scripts!